### PR TITLE
Adding default title tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,8 +5,10 @@
 		{% if page.collectionpage %}
 			{% assign collectiondata = site.collections | where: "label", page.collectionpage | first %}
 			<title>{{ collectiondata.title }} - {{ site.title }}</title>
-		{% else %}
+		{% elsif page.title %}
 			<title>{{ page.title }} - {{ site.title }}</title>
+		{% else %}
+			<title>{{ site.title }}</title>
 		{% endif %}
 
 		<link rel="stylesheet" href="{{ "/assets/styles.css" | relative_url }}">


### PR DESCRIPTION
Currently, if page.collectionpage and page.title are both unset, the page title is set to " - Whatever Blog Title". This is undesirable, so if neither variable is set, the title tag should just be "Whatever Blog Title".